### PR TITLE
fix: playlist track data extraction

### DIFF
--- a/src/Info.ts
+++ b/src/Info.ts
@@ -95,7 +95,7 @@ export const getAlbum = async (url: string = ''): Promise<Album | string> => {
         let yt_tracks: any | undefined = await get_album_playlist(alb[0].playlistId) // Get track ids from youtube
         spTrk.tracks.items.forEach((i: any, n: number) => {
             tags.tracks.push({
-                name: i.track.name,
+                title: i.track.name,
                 id: yt_tracks[n].playlistVideoRenderer.videoId,
                 trackNumber: i.track.trackNumber
             })

--- a/src/Info.ts
+++ b/src/Info.ts
@@ -130,17 +130,17 @@ export const getPlaylist = async (url: string = ''): Promise<Playlist | string> 
             followerCount: spPlaylist.followers,
             trackCount: spPlaylist.content.totalCount,
             tracks: spPlaylist.content.items.map(async (trk: any) => {
-                let trackTitle = trk.item.data.name
-                let trackArtists = trk.item.data.artists.items.map((i: any) => i.profile.name).join(', ')
+                let trackTitle = trk.itemV2.data.name
+                let trackArtists = trk.itemV2.data.artists.items.map((i: any) => i.profile.name).join(', ')
                 let yt_trk = await ytm.searchSongs(`${trackTitle} - ${trackArtists}`)
                 return {
                     title: trackTitle,
                     artist: trackArtists,
                     // year: Does not exist when scraping
-                    album: trk.item.data.albumOfTrack.name,
+                    album: trk.itemV2.data.albumOfTrack.name,
                     id: yt_trk[0].videoId,
-                    albumCoverURL: trk.item.data.albumOfTrack.coverArt.sources[0].url,
-                    trackNumber: trk.item.data.trackNumber
+                    albumCoverURL: trk.itemV2.data.albumOfTrack.coverArt.sources[0].url,
+                    trackNumber: trk.itemV2.data.trackNumber
                 }
             }),
             playlistCoverURL: spPlaylist.images.items[0].sources[0].url


### PR DESCRIPTION
Playlist track data is now seem to be stored in `itemV2` rather than `item`.